### PR TITLE
:zap:feat:updatedAt

### DIFF
--- a/src/main/java/org/example/plan/entity/BaseEntity.java
+++ b/src/main/java/org/example/plan/entity/BaseEntity.java
@@ -15,11 +15,9 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-    //생성시간과 수정시간을 추상화로 관리
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
 }
+
+

--- a/src/main/java/org/example/plan/entity/Member.java
+++ b/src/main/java/org/example/plan/entity/Member.java
@@ -3,6 +3,9 @@ package org.example.plan.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -27,4 +30,5 @@ public class Member extends BaseEntity{
 
     public Member() {
     }
+
 }

--- a/src/main/java/org/example/plan/entity/Plan.java
+++ b/src/main/java/org/example/plan/entity/Plan.java
@@ -3,6 +3,7 @@ package org.example.plan.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +23,9 @@ public class Plan extends BaseEntity {
     @Column(columnDefinition = "longtext")
     private String contents;
 
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
     @Setter
     @ManyToOne
     @JoinColumn(name = "member_id")
@@ -32,7 +36,6 @@ public class Plan extends BaseEntity {
         this.title = title;
         this.contents = contents;
     }
-
 
     public Plan() {
 


### PR DESCRIPTION
공통으로 추상화 되어 있던 시작 작성일과 수정일을 나누어서 멤버에는 작성일만 표기되게 하고, 플랜에게는 작성일과 수정일 모두 포함하게 변경